### PR TITLE
Change context to 'Editing Text'

### DIFF
--- a/com.asparck.eclipse.multicursor.plugin/plugin.xml
+++ b/com.asparck.eclipse.multicursor.plugin/plugin.xml
@@ -27,12 +27,12 @@
 
     <extension point="org.eclipse.ui.bindings">
         <key commandId="com.asparck.multicursor.commands.selectAllOccurrences"
-                contextId="org.eclipse.ui.contexts.window"
+                contextId="org.eclipse.ui.textEditorScope"
                 sequence="M1+M2+I"
                 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
         </key>
         <key commandId="com.asparck.multicursor.commands.selectNextOccurrence"
-                contextId="org.eclipse.ui.contexts.window"
+                contextId="org.eclipse.ui.textEditorScope"
                 sequence="M1+M2+D"
                 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
         </key>


### PR DESCRIPTION
The 'In Windows' context is too wide and increases the change for key
binding conflicts with other plugins. The 'Editing Text' context seems
to be the right one for these commands.

Here is an example conflict I get:

```
!ENTRY org.eclipse.jface 2 0 2014-10-08 10:17:08.316
!MESSAGE Keybinding conflicts occurred.  They may interfere with normal accelerator operation.
!SUBENTRY 1 org.eclipse.jface 2 0 2014-10-08 10:17:08.316
!MESSAGE A conflict occurred for CTRL+SHIFT+D:
Binding(CTRL+SHIFT+D,
    ParameterizedCommand(Command(org.eclipse.jdt.debug.ui.commands.Display,Display,
        Display result of evaluating selected text,
        Category(org.eclipse.debug.ui.category.run,Run/Debug,Run/Debug command category,true),
        org.eclipse.ui.internal.WorkbenchHandlerServiceHandler@abcfc1,
        ,,true),null),
    org.eclipse.ui.defaultAcceleratorConfiguration,
    org.eclipse.ui.contexts.dialogAndWindow,,,system)
Binding(CTRL+SHIFT+D,
    ParameterizedCommand(Command(org.jkiss.dbeaver.core.object.goto,Open Database Object ...,
        Open database meta object,
        Category(org.jkiss.dbeaver.core.database,Connection,Database Connection Commands,true),
        org.eclipse.ui.internal.WorkbenchHandlerServiceHandler@1d4c2b7,
        ,,true),null),
    org.eclipse.ui.defaultAcceleratorConfiguration,
    org.eclipse.ui.contexts.window,,,system)
Binding(CTRL+SHIFT+D,
    ParameterizedCommand(Command(com.asparck.multicursor.commands.selectNextOccurrence,Select Next Occurrence,
        ,
        Category(com.asparck.multicursor.commands.category,MultiCursor,null,true),
        org.eclipse.ui.internal.WorkbenchHandlerServiceHandler@13bb4b6,
        ,,true),null),
    org.eclipse.ui.defaultAcceleratorConfiguration,
    org.eclipse.ui.contexts.window,,,system)
```
