### PR TITLE
Change hotkey for 'Select All Occurrences' to Alt+F3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ What works?
 -----------
 
 * `Ctrl+Shift+D`: "Select Next Occurrence" of the selected text & start editing it. Repeat to select remaining occurrences.
-* `Ctrl+Shift+I`: "Select All Occurrences" of the selected text & start editing all of them at once.
+* `Alt+F3`: "Select All Occurrences" of the selected text & start editing all of them at once.
 
 (If you haven't got anything selected, it'll expand your selection to the word under the cursor, or to the whole line if the cursor is in whitespace.)
 

--- a/com.asparck.eclipse.multicursor.plugin/plugin.xml
+++ b/com.asparck.eclipse.multicursor.plugin/plugin.xml
@@ -28,7 +28,7 @@
     <extension point="org.eclipse.ui.bindings">
         <key commandId="com.asparck.multicursor.commands.selectAllOccurrences"
                 contextId="org.eclipse.ui.contexts.window"
-                sequence="M1+M2+I"
+                sequence="M3+F3"
                 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
         </key>
         <key commandId="com.asparck.multicursor.commands.selectNextOccurrence"


### PR DESCRIPTION
Ctrl+Shift+I is in conflict with the Inspect command during code
debugging, even if when the context is changed from 'In Windows' to
'Text Editing'.

Therefore, it is better to select new hotkey. Alt+F3 is like in Sublime
Text and it is absolutely free (checked with an Eclipse product with a
large list of plugins).
