### PR TITLE
Change hotkey for 'Select Next Occurrence' to Ctrl+Alt+D

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An attempt to provide (fairly limited) Sublime-Text-like multi cursor support fo
 What works?
 -----------
 
-* `Ctrl+Shift+D`: "Select Next Occurrence" of the selected text & start editing it. Repeat to select remaining occurrences.
+* `Ctrl+Alt+D`: "Select Next Occurrence" of the selected text & start editing it. Repeat to select remaining occurrences.
 * `Ctrl+Shift+I`: "Select All Occurrences" of the selected text & start editing all of them at once.
 
 (If you haven't got anything selected, it'll expand your selection to the word under the cursor, or to the whole line if the cursor is in whitespace.)

--- a/com.asparck.eclipse.multicursor.plugin/plugin.xml
+++ b/com.asparck.eclipse.multicursor.plugin/plugin.xml
@@ -33,7 +33,7 @@
         </key>
         <key commandId="com.asparck.multicursor.commands.selectNextOccurrence"
                 contextId="org.eclipse.ui.contexts.window"
-                sequence="M1+M2+D"
+                sequence="M1+M3+D"
                 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
         </key>
    </extension>


### PR DESCRIPTION
Ctrl+Shift+D is in conflict with the 'Match Pair Inward' command of the
Emmet plugin. Emmet is a popular plugin among web developers and when
installed the 'Select Next Occurence' command does not work.

Therefore, it is better to select new hotkey. Ctrl+Alt+D is still not
very different from Ctrl+Shift+D, it's free and there are also lots of
other Ctrl+Alt+<key> shortcuts for text editing in the Eclipse Platform
and AnyEdit plugin. So, it is a good group to be inside.
