### PR TITLE
New key bindings for commands

### DIFF
--- a/com.asparck.eclipse.multicursor.plugin/plugin.xml
+++ b/com.asparck.eclipse.multicursor.plugin/plugin.xml
@@ -28,12 +28,38 @@
     <extension point="org.eclipse.ui.bindings">
         <key commandId="com.asparck.multicursor.commands.selectAllOccurrences"
                 contextId="org.eclipse.ui.textEditorScope"
-                sequence="M1+M2+I"
+                sequence="ALT+F3"
+                platform="win32"
+                schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
+        </key>
+        <key commandId="com.asparck.multicursor.commands.selectAllOccurrences"
+                contextId="org.eclipse.ui.textEditorScope"
+                sequence="ALT+F3"
+                platform="gtk"
+                schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
+        </key>
+        <key commandId="com.asparck.multicursor.commands.selectAllOccurrences"
+                contextId="org.eclipse.ui.textEditorScope"
+                sequence="CTRL+COMMAND+G"
+                platform="cocoa"
                 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
         </key>
         <key commandId="com.asparck.multicursor.commands.selectNextOccurrence"
                 contextId="org.eclipse.ui.textEditorScope"
-                sequence="M1+M2+D"
+                sequence="ALT+J"
+                platform="win32"
+                schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
+        </key>
+        <key commandId="com.asparck.multicursor.commands.selectNextOccurrence"
+                contextId="org.eclipse.ui.textEditorScope"
+                sequence="ALT+J"
+                platform="gtk"
+                schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
+        </key>
+        <key commandId="com.asparck.multicursor.commands.selectNextOccurrence"
+                contextId="org.eclipse.ui.textEditorScope"
+                sequence="CTRL+G"
+                platform="cocoa"
                 schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
         </key>
    </extension>


### PR DESCRIPTION
Existing Ctrl+Shift+I and Ctrl+Shift+D key binding run with conflict
with commands with the same keybings from the Eclipse Platform and other
plugins.

This patch proposes new keybindings:
- Select All Occurrences: Alt+F3 (Win, Linux) / Ctrl+Cmd+G (Mac)
- Select Next Occurrence: Alt+J (Win, Linux) / Ctrl+G (Mac)
