### PR TITLE
Undo suspended during linked mode

### DIFF
--- a/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectAllOccurrencesHandler.java
+++ b/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectAllOccurrencesHandler.java
@@ -75,6 +75,7 @@ public class SelectAllOccurrencesHandler extends AbstractHandler {
 			LinkedModeModel model = new LinkedModeModel();
 			model.addGroup(linkedPositionGroup);
 			model.forceInstall();
+			model.addLinkingListener(new UndoSuspender());
 
 			LinkedModeUI ui = new EditorLinkedModeUI(model, viewer);
 			ui.setExitPolicy(new DeleteBlockingExitPolicy(document));

--- a/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectNextOccurrenceHandler.java
+++ b/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectNextOccurrenceHandler.java
@@ -145,7 +145,7 @@ public class SelectNextOccurrenceHandler extends AbstractHandlerWithState {
 		model.addGroup(linkedPositionGroup);
 		model.forceInstall();
 		//FIXME can add a listener here to listen for the end of linked mode
-		//model.addLinkingListener(null);
+		model.addLinkingListener(new UndoSuspender());
 
 		LinkedModeUI ui = new EditorLinkedModeUI(model, viewer);
 		ui.setExitPolicy(new DeleteBlockingExitPolicy(viewer.getDocument()));

--- a/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/UndoSuspender.java
+++ b/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/UndoSuspender.java
@@ -1,0 +1,50 @@
+package com.asparck.eclipse.multicursor.handlers;
+
+import org.eclipse.core.commands.operations.IOperationApprover;
+import org.eclipse.core.commands.operations.IOperationHistory;
+import org.eclipse.core.commands.operations.IUndoableOperation;
+import org.eclipse.core.commands.operations.OperationHistoryFactory;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.text.link.ILinkedModeListener;
+import org.eclipse.jface.text.link.LinkedModeModel;
+
+public class UndoSuspender implements ILinkedModeListener {
+
+	IOperationApprover operationApprover = new IOperationApprover() {
+
+		@Override
+		public IStatus proceedUndoing(IUndoableOperation operation,
+				IOperationHistory history, IAdaptable info) {
+			return Status.CANCEL_STATUS;
+		}
+
+		@Override
+		public IStatus proceedRedoing(IUndoableOperation operation,
+				IOperationHistory history, IAdaptable info) {
+			return Status.CANCEL_STATUS;
+		}
+	};
+
+	private IOperationHistory operationHistory;
+
+	public UndoSuspender() {
+		this.operationHistory = OperationHistoryFactory.getOperationHistory();
+		this.operationHistory.addOperationApprover(operationApprover);
+	}
+
+	@Override
+	public void left(LinkedModeModel model, int flags) {
+		operationHistory.removeOperationApprover(operationApprover);
+	}
+
+	@Override
+	public void suspend(LinkedModeModel model) {
+	}
+
+	@Override
+	public void resume(LinkedModeModel model, int flags) {
+	}
+
+}


### PR DESCRIPTION
This change will suspend Undo/Redo in linked mode (https://github.com/caspark/eclipse-multicursor/issues/16). It should prevent linked mode from breaking code after many undo operation in linked mode.
