### PR TITLE
Undo suspended during linked mode

### DIFF
--- a/com.asparck.eclipse.multicursor.plugin/META-INF/MANIFEST.MF
+++ b/com.asparck.eclipse.multicursor.plugin/META-INF/MANIFEST.MF
@@ -9,8 +9,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.jface.text;bundle-version="3.7.0",
  org.eclipse.ui.workbench.texteditor;bundle-version="3.7.0",
- org.eclipse.wst.sse.core;bundle-version="1.1.900",
- org.eclipse.emf.common
+ org.eclipse.wst.sse.core;resolution:=optional,
+ org.eclipse.emf.common;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: com.asparck.eclipse.multicursor.util

--- a/com.asparck.eclipse.multicursor.plugin/META-INF/MANIFEST.MF
+++ b/com.asparck.eclipse.multicursor.plugin/META-INF/MANIFEST.MF
@@ -8,7 +8,9 @@ Bundle-Vendor: Caspar Krieger
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.jface.text;bundle-version="3.7.0",
- org.eclipse.ui.workbench.texteditor;bundle-version="3.7.0"
+ org.eclipse.ui.workbench.texteditor;bundle-version="3.7.0",
+ org.eclipse.wst.sse.core;bundle-version="1.1.900",
+ org.eclipse.emf.common
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: com.asparck.eclipse.multicursor.util

--- a/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectAllOccurrencesHandler.java
+++ b/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectAllOccurrencesHandler.java
@@ -75,7 +75,7 @@ public class SelectAllOccurrencesHandler extends AbstractHandler {
 			LinkedModeModel model = new LinkedModeModel();
 			model.addGroup(linkedPositionGroup);
 			model.forceInstall();
-			model.addLinkingListener(new UndoSuspender());
+			model.addLinkingListener(new UndoSuspender(viewer.getDocument()));
 
 			LinkedModeUI ui = new EditorLinkedModeUI(model, viewer);
 			ui.setExitPolicy(new DeleteBlockingExitPolicy(document));

--- a/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectAllOccurrencesHandler.java
+++ b/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectAllOccurrencesHandler.java
@@ -75,6 +75,7 @@ public class SelectAllOccurrencesHandler extends AbstractHandler {
 			LinkedModeModel model = new LinkedModeModel();
 			model.addGroup(linkedPositionGroup);
 			model.forceInstall();
+			model.addLinkingListener(new UndoSuspender());
 
 			LinkedModeUI ui = new EditorLinkedModeUI(model, viewer);
 			ui.setExitPolicy(new DeleteBlockingExitPolicy(document));

--- a/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectNextOccurrenceHandler.java
+++ b/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectNextOccurrenceHandler.java
@@ -145,7 +145,7 @@ public class SelectNextOccurrenceHandler extends AbstractHandlerWithState {
 		model.addGroup(linkedPositionGroup);
 		model.forceInstall();
 		//FIXME can add a listener here to listen for the end of linked mode
-		model.addLinkingListener(new UndoSuspender());
+		model.addLinkingListener(new UndoSuspender(viewer.getDocument()));
 
 		LinkedModeUI ui = new EditorLinkedModeUI(model, viewer);
 		ui.setExitPolicy(new DeleteBlockingExitPolicy(viewer.getDocument()));
@@ -173,8 +173,8 @@ public class SelectNextOccurrenceHandler extends AbstractHandlerWithState {
 
 	@Override
 	public void handleStateChange(State state, Object oldValue) {
-//		logger.debug("State changed; new value=" + state.getId() + ":" + state.getValue() + " and old value="
-//				+ oldValue);
+		//		logger.debug("State changed; new value=" + state.getId() + ":" + state.getValue() + " and old value="
+		//				+ oldValue);
 	}
 
 }

--- a/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectNextOccurrenceHandler.java
+++ b/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/SelectNextOccurrenceHandler.java
@@ -145,7 +145,7 @@ public class SelectNextOccurrenceHandler extends AbstractHandlerWithState {
 		model.addGroup(linkedPositionGroup);
 		model.forceInstall();
 		//FIXME can add a listener here to listen for the end of linked mode
-		//model.addLinkingListener(null);
+		model.addLinkingListener(new UndoSuspender());
 
 		LinkedModeUI ui = new EditorLinkedModeUI(model, viewer);
 		ui.setExitPolicy(new DeleteBlockingExitPolicy(viewer.getDocument()));

--- a/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/UndoSuspender.java
+++ b/com.asparck.eclipse.multicursor.plugin/src/com/asparck/eclipse/multicursor/handlers/UndoSuspender.java
@@ -1,0 +1,50 @@
+package com.asparck.eclipse.multicursor.handlers;
+
+import org.eclipse.core.commands.operations.IOperationApprover;
+import org.eclipse.core.commands.operations.IOperationHistory;
+import org.eclipse.core.commands.operations.IUndoableOperation;
+import org.eclipse.core.commands.operations.OperationHistoryFactory;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.text.link.ILinkedModeListener;
+import org.eclipse.jface.text.link.LinkedModeModel;
+
+public class UndoSuspender implements ILinkedModeListener {
+
+	IOperationApprover operationApprover = new IOperationApprover() {
+
+		@Override
+		public IStatus proceedUndoing(IUndoableOperation operation,
+				IOperationHistory history, IAdaptable info) {
+			return Status.CANCEL_STATUS;
+		}
+
+		@Override
+		public IStatus proceedRedoing(IUndoableOperation operation,
+				IOperationHistory history, IAdaptable info) {
+			return Status.CANCEL_STATUS;
+		}
+	};
+
+	private IOperationHistory operationHistory;
+
+	public UndoSuspender() {
+		this.operationHistory = OperationHistoryFactory.getOperationHistory();
+		this.operationHistory.addOperationApprover(operationApprover);
+	}
+
+	@Override
+	public void left(LinkedModeModel model, int flags) {
+		operationHistory.removeOperationApprover(operationApprover);
+	}
+
+	@Override
+	public void suspend(LinkedModeModel model) {
+	}
+
+	@Override
+	public void resume(LinkedModeModel model, int flags) {
+	}
+
+}

--- a/com.asparck.eclipse.multicursor.target/com.asparck.eclipse.multicursor.target.target
+++ b/com.asparck.eclipse.multicursor.target/com.asparck.eclipse.multicursor.target.target
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="target" sequenceNumber="8">
+<?pde version="3.8"?><target name="target" sequenceNumber="13">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.platform.sdk" version="3.7.2.M20120208-0800"/>
 <unit id="org.eclipse.sdk.ide" version="3.7.2.M20120208-0800"/>
 <repository location="http://download.eclipse.org/eclipse/updates/3.7"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.3.2.v201111030500-7O7IFj6EMjB7yO1Xs_G1kMtQeOye6HTXFWve95_R"/>
+<unit id="org.eclipse.emf.sdk.feature.group" version="2.7.2.v20120130-0943"/>
+<repository location="http://download.eclipse.org/releases/indigo"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
This patch should disable Undo in linked mode (undo after applying change is possible). It supports editors that are using IOperationHistory to maintain Undo/Redo mechanism and also editors that are using IStructuredTextUndoManager for this (editors like: HTML, PHP, JS). Additional dependencies (EMF, WST) are marked as Optional and final user doesn't need to have it. I'm aware that it is more like a hack:)